### PR TITLE
Fix 3D rendering (Atleast in my modified version)

### DIFF
--- a/.base/lua/libraries/render/framebuffer.lua
+++ b/.base/lua/libraries/render/framebuffer.lua
@@ -15,6 +15,9 @@ function META:Begin(attach, channel, skip_push)
 	
 	gl.Viewport(0, 0, self.width, self.height)
 
+	gl.Clear(bit.bor(e.GL_COLOR_BUFFER_BIT, e.GL_DEPTH_BUFFER_BIT))	
+	gl.ClearColor(0, 0, 0, 1)
+
 	gl.ActiveTextureARB(channel or e.GL_TEXTURE0)
 	gl.Enable(e.GL_TEXTURE_2D)
 


### PR DESCRIPTION
I noticed you moved the gl.Clear and gl.ClearColor functions to a META:Clear function in framebuffer.lua, I didn't bother to check where this is called I just added the lines into the META:Begin function because I know it fixes it. Hopefully this is all that fixed it in mine, if its not let me know. Mine is heavily modified.
